### PR TITLE
Fix check warning for `max_document_size`, `max_http_request_size`

### DIFF
--- a/conf/local.ini
+++ b/conf/local.ini
@@ -1,8 +1,10 @@
 [couchdb]
 single_node=true
+max_document_size = 50000000
 
 [chttpd]
 require_valid_user = true
+max_http_request_size = 4294967296
 
 [chttpd_auth]
 require_valid_user = true


### PR DESCRIPTION
obsidian-livesync's `Check database configuration` print some warning for `max_document_size`, `max_http_request_size`.
![image](https://user-images.githubusercontent.com/9838749/203482158-797fc627-41ac-4abb-8a21-7af8c75d83fe.png)
