### PR TITLE
add local.d as volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
             # So when you want to perform git pull or change something, you have to change owners back.
             - ./data/couchdb:/opt/couchdb/data
             - ./conf/local.ini:/opt/couchdb/etc/local.ini
+            - ./local.d:/opt/couchdb/etc/local.d
         networks:
             - caddy
         labels:


### PR DESCRIPTION
When setting up obsidian live-sync with this compose file as reference, it wouldn't save the CORS settings made by `curl -s https://raw.githubusercontent.com/vrtmrz/obsidian-livesync/main/utils/couchdb/couchdb-init.sh | bash` as instructed by the settings. This was due to local.d being saved as a bind mount. I added it so that the settings made by couchdb-init.sh persists even after the container is deleted